### PR TITLE
OCMockObject: release invocation arguments on stopMocking.

### DIFF
--- a/Source/OCMockTests/OCMockObjectClassMethodMockingTests.m
+++ b/Source/OCMockTests/OCMockObjectClassMethodMockingTests.m
@@ -25,6 +25,7 @@
 @interface TestClassWithClassMethods : NSObject
 + (NSString *)foo;
 + (NSString *)bar;
++ (void)bazWithArgument:(id)argument;
 - (NSString *)bar;
 @end
 
@@ -50,6 +51,10 @@ static NSUInteger initializeCallCount = 0;
 + (NSString *)bar
 {
     return @"Bar-ClassMethod";
+}
+
++ (void)bazWithArgument:(id)argument
+{
 }
 
 - (NSString *)bar
@@ -303,6 +308,19 @@ static NSUInteger initializeCallCount = 0;
     id newObject = [TestClassWithClassMethods new];
 
     XCTAssertEqualObjects(dummyObject, newObject, @"Should have stubbed +new method");
+}
+
+- (void)testArgumentsGetReleasedAfterStopMocking
+{
+    __weak id weakArgument;
+    id mock = OCMClassMock([TestClassWithClassMethods class]);
+    @autoreleasepool {
+        NSObject *argument = [NSObject new];
+        weakArgument = argument;
+        [TestClassWithClassMethods bazWithArgument:argument];
+        [mock stopMocking];
+    }
+    XCTAssertNil(weakArgument);
 }
 
 @end

--- a/Source/OCMockTests/OCMockObjectPartialMocksTests.m
+++ b/Source/OCMockTests/OCMockObjectPartialMocksTests.m
@@ -67,6 +67,7 @@ static NSUInteger initializeCallCount = 0;
 - (NSRect)methodRect2;
 - (int)methodInt;
 - (void)methodVoid;
+- (void)methodVoidWithArgument:(id)argument;
 - (void)setMethodInt:(int)anInt;
 @end
 
@@ -101,6 +102,10 @@ static NSUInteger initializeCallCount = 0;
 }
 
 - (void)methodVoid
+{
+}
+
+- (void)methodVoidWithArgument:(id)argument
 {
 }
 
@@ -466,6 +471,20 @@ static NSUInteger initializeCallCount = 0;
 	XCTAssertEqualObjects(@"TestFoo", [realObject foo], @"Should have stubbed method.");
 	[mock stopMocking];
 	XCTAssertEqualObjects(@"Foo", [realObject foo], @"Should have 'unstubbed' method.");
+}
+
+- (void)testArgumentsGetReleasedAfterStopMocking
+{
+    __weak id weakArgument;
+    TestClassThatCallsSelf *realObject = [[TestClassThatCallsSelf alloc] init];
+    id mock = OCMPartialMock(realObject);
+    @autoreleasepool {
+        NSObject *argument = [NSObject new];
+        weakArgument = argument;
+        [mock methodVoidWithArgument:argument];
+        [mock stopMocking];
+    }
+    XCTAssertNil(weakArgument);
 }
 
 

--- a/Source/OCMockTests/OCMockObjectProtocolMocksTests.m
+++ b/Source/OCMockTests/OCMockObjectProtocolMocksTests.m
@@ -27,6 +27,7 @@
 - (int)primitiveValue;
 @optional
 - (id)objectValue;
+- (void)voidWithArgument:(id)argument;
 @end
 
 @interface InterfaceForTypedef : NSObject {
@@ -150,6 +151,19 @@ typedef InterfaceForTypedef* PointerTypedefInterface;
 - (void)testRefusesToCreateProtocolMockForNilProtocol
 {
     XCTAssertThrows(OCMProtocolMock(nil));
+}
+
+- (void)testArgumentsGetReleasedAfterStopMocking
+{
+    __weak id weakArgument;
+    id mock = OCMProtocolMock(@protocol(TestProtocol));
+    @autoreleasepool {
+        NSObject *argument = [NSObject new];
+        weakArgument = argument;
+        [mock voidWithArgument:argument];
+        [mock stopMocking];
+    }
+    XCTAssertNil(weakArgument);
 }
 
 @end

--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -1138,6 +1138,19 @@ static NSString *TestNotification = @"TestNotification";
     XCTAssertTrue([end timeIntervalSinceDate:start] < 3, @"Should have returned before delay was up");
 }
 
+- (void)testArgumentsGetReleasedAfterStopMocking
+{
+    __weak id weakArgument;
+    mock = OCMClassMock([TestClassWithProperty class]);
+    @autoreleasepool {
+        NSMutableString *title = [NSMutableString new];
+        weakArgument = title;
+        [mock setTitle:title];
+        [mock stopMocking];
+    }
+    XCTAssertNil(weakArgument);
+}
+
 @end
 
 


### PR DESCRIPTION
OCMockObject invocations need to retain their arguments, however that can introduce retain cycles that wouldn't otherwise be there. It also makes dealloc tests fail for objects that get sent as arguments to mocks.
Break the chain in -stopMocking by emptying out the invocations.

https://github.com/erikdoe/ocmock/issues/307